### PR TITLE
highlight beyond fill-column

### DIFF
--- a/hl-fill-column.el
+++ b/hl-fill-column.el
@@ -64,7 +64,7 @@ Look through END when provided."
     (if (and (= fill-column (current-column))
              (<= (point) end)
              (> (point) start))
-        (progn (set-match-data (list (1- (point)) (point)))
+        (progn (set-match-data (list (point) (+ 1 (point))))
                t)                       ; Return t.
       (goto-char start)
       nil)))                            ; Return nil.


### PR DESCRIPTION
The documentation of `fill-column` says: Column *beyond* which automatic line-wrapping should happen.

At the moment if `fill-column` is set at `80` when you call `fill-paragraph` and you end up with a line of exactly `80` character, the last character of this line will be highlighted even though it's already correctly filled. What I suggest is to highlight the character beyond `fill-column` to avoid false positive matches.