### PR TITLE
don't highlight empty end of line

### DIFF
--- a/hl-fill-column.el
+++ b/hl-fill-column.el
@@ -45,26 +45,27 @@
 (defun -find (end)
   "Function to locate a character in fill column.
 Look through END when provided."
-  (let ((start (point)))
+  (let ((start (point))
+        (after-fill-column (+ 1 fill-column)))
     (when (> end (point-max)) (setq end (point-max)))
 
     ;; Try to keep `move-to-column' from going backward, though it still can.
-    (unless (< (current-column) fill-column) (forward-line 1))
+    (unless (< (current-column) after-fill-column) (forward-line 1))
 
     ;; Again, don't go backward.  Try to move to correct column.
-    (when (< (current-column) fill-column) (move-to-column fill-column))
+    (when (< (current-column) after-fill-column) (move-to-column after-fill-column))
 
     ;; If not at target column, try to move to it.
-    (while (and (< (current-column) fill-column) (< (point) end)
+    (while (and (< (current-column) after-fill-column) (< (point) end)
                 (= 0 (+ (forward-line 1) (current-column)))) ; Should be bol.
-      (move-to-column fill-column))
+      (move-to-column after-fill-column))
 
     ;; If at target column, not past end, and not prior to start, then set match
     ;; data and return t.  Otherwise go to start and return nil.
-    (if (and (= fill-column (current-column))
+    (if (and (= after-fill-column (current-column))
              (<= (point) end)
              (> (point) start))
-        (progn (set-match-data (list (point) (+ 1 (point))))
+        (progn (set-match-data (list (1- (point)) (point)))
                t)                       ; Return t.
       (goto-char start)
       nil)))                            ; Return nil.


### PR DESCRIPTION
Revert and fix previous commit that highlighted the end of lines when
they were of length `fill-column`.

You can see the issue introduced by my previous PR on the following image, `fill-column` is set to 80.
![1559900829](https://user-images.githubusercontent.com/5525646/59095935-05bdf180-891a-11e9-8806-b6193cceac0a.png)

I hope that I didn't broke anything this time...